### PR TITLE
Refactor to use rand::distributions::Exp instead

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,15 +41,18 @@ struct PacketGenerator<'a> {
     last_gen: u32,
     // Ticks till next packet is generated.
     till_next: u32,
+    // The "length" of time of one tick
+    time_delta: f64,
     tg: &'a EventGenerator,
 }
 
 impl<'a> PacketGenerator<'a> {
-    fn new(tg: &EventGenerator) -> PacketGenerator {
+    fn new(tg: &EventGenerator, time_delta: f64) -> PacketGenerator {
         PacketGenerator {
             last_gen: 0,
             till_next: 0,
             tg: tg,
+            time_delta: time_delta,
         }
     }
 
@@ -58,7 +61,7 @@ impl<'a> PacketGenerator<'a> {
     fn next_packet(&mut self, time: u32) -> Option<Packet> {
         if time - self.last_gen == self.till_next {
             self.last_gen = time;
-            self.till_next = self.tg.next_event(1e6);
+            self.till_next = self.tg.next_event(self.time_delta);
             Some(Packet(time))
         } else {
             None
@@ -94,7 +97,7 @@ mod tests {
     #[test]
     fn test_packet_generator() {
         let tg = TestGenerator(5);
-        let mut pg = PacketGenerator::new(&tg);
+        let mut pg = PacketGenerator::new(&tg, 1e6);
         let mut packet = pg.next_packet(0);
         assert_eq!(packet.expect("invalid value").0, 0);
         assert_eq!(pg.last_gen, 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,50 +1,51 @@
 extern crate rand;
 
-use rand::distributions::{IndependentSample, Range};
+use rand::distributions::{Exp, IndependentSample};
 
-trait TimeGenerator {
-    fn generate(&self) -> u32;
+// The underlying RNG, if configured (consider λ in an exponentially distributed generator for
+// e.g.), should map to an events/s parameter. next_event returns an u32 integer corresponding to
+// how many discrete time units of the specified resolution (1e6 for a µs scale for e.g.) would
+// need to pass until the next such event.
+// If the resolution is too course (1 for e.g.  corresponding to a second resolution) the return
+// value might be 0, this just means we've lost potentially useful information due to rounding up
+// errors.  If the next event was to occur after 5ms, a specified resolution of a second scale
+// asking for the next second the event would occur would return 0 -- hardly useful information.
+trait EventGenerator {
+    fn next_event(&self, resolution: f64) -> u32;
 }
 
-/* MarkovianGenerator generates random numbers that fit an exponential distribution */
-struct MarkovianGenerator {
-    lambda: f64,
-    range: Range<f64>,
+// ExponentialGenerator generates random numbers that fit an exponential
+// distribution.
+pub struct ExponentialGenerator {
+    exp: Exp,
 }
 
-impl MarkovianGenerator {
-    fn new(lambda: f64) -> MarkovianGenerator {
-        let range: Range<f64> = Range::new(0.0, 1.0);
-        MarkovianGenerator {
-            lambda: lambda,
-            range: range,
-        }
+impl ExponentialGenerator {
+    fn new(lambda: f64) -> ExponentialGenerator {
+        ExponentialGenerator { exp: Exp::new(lambda) }
     }
 }
 
-impl TimeGenerator for MarkovianGenerator {
-    fn generate(&self) -> u32 {
-        let mut rng = rand::thread_rng();
-        let u = self.range.ind_sample(&mut rng);
-        // Use a tick duration of 1 microsecond like in lab manual example
-        ((-1.0 / self.lambda) * (1.0 - u).ln() * 1_000_000.0).trunc() as u32
+impl EventGenerator for ExponentialGenerator {
+    fn next_event(&self, resolution: f64) -> u32 {
+        (self.exp.ind_sample(&mut rand::thread_rng()) * resolution) as u32
     }
 }
 
-// Packet holds the value of the time in ticks that it was generated at
+// Packet holds the value of the time in ticks that it was generated at.
 struct Packet(u32);
 
-// PacketGenerator generates packets according to an AvailabilityTimeGenerator
+// PacketGenerator generates packets according to a provided EventGenerator.
 struct PacketGenerator<'a> {
-    // Last tick that a packet was generated
+    // Last tick that a packet was generated.
     last_gen: u32,
-    // Ticks till next packet is generated
+    // Ticks till next packet is generated.
     till_next: u32,
-    tg: &'a TimeGenerator,
+    tg: &'a EventGenerator,
 }
 
 impl<'a> PacketGenerator<'a> {
-    fn new(tg: &TimeGenerator) -> PacketGenerator {
+    fn new(tg: &EventGenerator) -> PacketGenerator {
         PacketGenerator {
             last_gen: 0,
             till_next: 0,
@@ -52,12 +53,12 @@ impl<'a> PacketGenerator<'a> {
         }
     }
 
-    // generate takes the current time and uses it to determine whether to generate a packet or not.
-    // if a packet is generated, the last_gen time and till_next times are both updated
-    fn generate(&mut self, time: u32) -> Option<Packet> {
+    // next_packet takes the current time and uses it to determine whether to generate a packet or not.
+    // If a packet is generated, the last_gen time and till_next times are both updated.
+    fn next_packet(&mut self, time: u32) -> Option<Packet> {
         if time - self.last_gen == self.till_next {
             self.last_gen = time;
-            self.till_next = self.tg.generate();
+            self.till_next = self.tg.next_event(1e6);
             Some(Packet(time))
         } else {
             None
@@ -69,20 +70,23 @@ impl<'a> PacketGenerator<'a> {
 mod tests {
     use super::*;
 
-    // Just testing to check that the numbers generated seem to be random... use
-    // cargo test -- --nocapture to see stdout
+    // Use `cargo test -- --nocapture` to verify the generation of exponentially distributed random
+    // u32 integers, at 100 packets/s and a µs scale resolution, a typical generation would be
+    // [8728, 12561, 4670, 5370, 9221].
     #[test]
-    fn print_random_numbers() {
-        let mg = MarkovianGenerator::new(100.0);
-        for i in 0..10 {
-            println!("{}", mg.generate())
+    fn generate_exponential_events() {
+        let eg = ExponentialGenerator::new(100.0);
+        let mut events = vec![];
+        for _ in 0..5 {
+            events.push(eg.next_event(1e6));
         }
+        println!("vals: {:?}", events)
     }
 
     struct TestGenerator(u32);
 
-    impl TimeGenerator for TestGenerator {
-        fn generate(&self) -> u32 {
+    impl EventGenerator for TestGenerator {
+        fn next_event(&self, _: f64) -> u32 {
             self.0
         }
     }
@@ -91,11 +95,11 @@ mod tests {
     fn test_packet_generator() {
         let tg = TestGenerator(5);
         let mut pg = PacketGenerator::new(&tg);
-        let mut packet = pg.generate(0);
+        let mut packet = pg.next_packet(0);
         assert_eq!(packet.expect("invalid value").0, 0);
         assert_eq!(pg.last_gen, 0);
         assert_eq!(pg.till_next, 5);
-        packet = pg.generate(3);
+        packet = pg.next_packet(3);
         assert!(packet.is_none());
         assert_eq!(pg.last_gen, 0);
         assert_eq!(pg.till_next, 5);


### PR DESCRIPTION
`rand::distributions::Exp` provides an exponential distribution out of the
box, augment `MarkovGenerator` (renamed to `ExponentialGenerator`) to use
that instead.

Introduce EventGenerators, that simply generate arbitrary "events"
according to some underlying distribution. This makes the  concept of
"resolution" explicit with the following API:

     trait EventGenerator {
        fn next_event(&self, resolution: f64) -> u32;
    }

The underlying RNG, if configured (consider λ in an exponentially
distributed generator for e.g.), should map to an events/s parameter.
`next_event` returns an u32 integer corresponding to how many discrete
time units of the specified resolution (1e6 for a µs scale for e.g.)
would need to pass until the next event.

The `PacketGenerator` implementation can probably me pulled into the ticker 
loop body instead of the generator keeping track of when the event is (@jack-mo).