### PR TITLE
Implement consume for consumer

### DIFF
--- a/src/consumers.rs
+++ b/src/consumers.rs
@@ -1,31 +1,90 @@
 use std::collections::VecDeque;
 use simulators::Packet;
 
-// Consumer has a VecDeque and its buffer size
-struct Consumer {
+// Consumer stores packets in a queue and processes them
+pub struct Consumer {
     queue: VecDeque<Packet>,
-    buffer_size: usize,
+    buffer_limit: Option<usize>,
+    service_time: u32,
+    state: State,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum State {
+    Idle,
+    // Processing holds the time that the consumer will be in processing till
+    Processing(u32),
 }
 
 impl Consumer {
-    fn new(buffer_size: usize) -> Consumer {
+    fn new(buffer_limit: Option<usize>, service_time: u32) -> Consumer {
         Consumer {
             queue: VecDeque::new(),
-            buffer_size: buffer_size,
+            buffer_limit: buffer_limit,
+            service_time: service_time,
+            state: State::Idle,
         }
     }
 
-    // If the consumer doesn't have a buffer size (if it's 0), it enques
-    // IF the consumer does have a buffer size, it enques when it's length is less then it's buffer size
-    fn enqueue(&mut self, packet: Packet) -> () {
-        if self.buffer_size == 0 {
-            self.queue.push_back(packet);
-        } else if self.queue.len() < self.buffer_size { 
-            self.queue.push_back(packet);
+    fn enqueue(&mut self, packet: Packet) -> bool {
+        match self.buffer_limit {
+            Some(size) => {
+                if self.queue.len() < size {
+                    self.queue.push_back(packet);
+                    true
+                } else {
+                    false
+                }
+            }
+            // buffer_size of none implies that it is an infinite queue
+            None => {
+                self.queue.push_back(packet);
+                true
+            }
         }
     }
 
-    fn dequeue(&mut self) -> Option<Packet> {
-        self.queue.pop_front()
+    fn consume(&mut self, time: u32) -> Option<Packet> {
+        match self.state {
+            State::Idle => {
+                if !self.queue.is_empty() {
+                    self.state = State::Processing(time + self.service_time);
+                }
+                None
+            }
+            State::Processing(dt) => {
+                let packet = if time >= dt {
+                    self.queue.pop_front()
+                } else {
+                    None
+                };
+                if self.queue.is_empty() {
+                    self.state = State::Idle;
+                } else {
+                    self.state = State::Processing(time + self.service_time);
+                }
+                packet
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_consume() {
+        let mut consumer = Consumer::new(None, 1);
+        consumer.queue.push_back(Packet(1));
+        consumer.queue.push_back(Packet(2));
+        let packet = consumer.consume(1);
+        assert_eq!(consumer.state, State::Processing(2));
+        assert!(packet.is_none());
+        let packet = consumer.consume(2);
+        assert_eq!(consumer.state, State::Processing(3));
+        assert_eq!(packet.expect("Should be 1").0, 1);
+        consumer.consume(3);
+        assert_eq!(consumer.state, State::Idle);
     }
 }

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -6,8 +6,9 @@ use self::rand::distributions::{Exp, IndependentSample};
 // used. The underlying RNG distribution, if configured (consider λ in an exponentially distributed
 // generator for e.g.), should map to an events/s parameter.
 pub trait Generator {
-    // next_event returns an u32 integer corresponding to how many discrete time units of the specified
-    // resolution (1e6 for a µs scale for e.g.) would need to pass until the next such event.
+    // next_event returns an u32 integer corresponding to how many discrete time units of the
+    // specified resolution (1e6 for a µs scale for e.g.) would need to pass until
+    // the next such event.
     //
     // NB: If the resolution is too course (1 for e.g. corresponding to a 1s resolution), the
     // return value might be 0, this just means we've potentially lost useful information due to

--- a/src/simulators.rs
+++ b/src/simulators.rs
@@ -6,10 +6,8 @@ pub struct Packet(pub u32);
 // Client generates packets according as per the provided generators::Generator.
 #[allow(dead_code)]
 struct Client<G: Generator> {
-    // Last tick that a packet was generated.
-    last_gen: u32,
-    // Ticks till next packet is generated.
-    till_next: u32,
+    // Next time value that a tick will be generated
+    next_gen: u32,
     // The "length" of time of one tick.
     resolution: f64,
     generator: G,
@@ -19,8 +17,7 @@ impl<G: Generator> Client<G> {
     #[allow(dead_code)]
     fn new(generator: G, resolution: f64) -> Client<G> {
         Client {
-            last_gen: 0,
-            till_next: 0,
+            next_gen: 0,
             generator: generator,
             resolution: resolution,
         }
@@ -30,9 +27,8 @@ impl<G: Generator> Client<G> {
     // not. If a packet is generated, the last_gen time and till_next times are both updated.
     #[allow(dead_code)]
     fn next_packet(&mut self, time: u32) -> Option<Packet> {
-        if time - self.last_gen == self.till_next {
-            self.last_gen = time;
-            self.till_next = self.generator.next_event(self.resolution);
+        if time == self.next_gen {
+            self.next_gen = time + self.generator.next_event(self.resolution);
             Some(Packet(time))
         } else {
             None
@@ -58,10 +54,8 @@ mod tests {
         let mut pg = Client::new(TestGenerator(5), 1e6);
 
         assert_eq!(pg.next_packet(0).expect("invalid value").0, 0);
-        assert_eq!(pg.last_gen, 0);
-        assert_eq!(pg.till_next, 5);
+        assert_eq!(pg.next_gen, 5);
         assert!(pg.next_packet(3).is_none());
-        assert_eq!(pg.last_gen, 0);
-        assert_eq!(pg.till_next, 5);
+        assert_eq!(pg.next_gen, 5);
     }
 }


### PR DESCRIPTION
Introduce State enum and make it a field in Consumer.
Idle indicates that the Consumer is ready to accept the packet, and
Processing(x) indicates that the Consumer is processing until time x.